### PR TITLE
Fixed index out of range error

### DIFF
--- a/webwrap.py
+++ b/webwrap.py
@@ -15,8 +15,11 @@ try:
 	reg = """\]LEDEBUT\]([\s\S]*)\]LAFIN\]"""
 
 	req = httpx.get(host.replace("WRAP", "echo -n ]LEDEBUT]$(whoami)[$(hostname)[$(pwd)]LAFIN]"))
-	prefixes = re.compile(reg).findall(req.text)[0].split("[")
-	path = prefixes[2]
+	prefixes = re.compile(reg).findall(req.text)
+	if not prefixes:
+		print("Req.text not found!\n")
+		exit(-1)
+	path = prefixes[0].split("[")[2]
 	prefix = colored(prefixes[0] + "@" + prefixes[1], "red") + ":" + colored(prefixes[2], "cyan") + "$ "
 	print("")
 


### PR DESCRIPTION
There could be a situation where `findall` doesn't find anything, in this case I add a check to avoid errors.

Fixes #1 